### PR TITLE
Fix unlock timer issue

### DIFF
--- a/application.py
+++ b/application.py
@@ -426,7 +426,7 @@ def UnlockCarTime(lock_time):
         vehicle.command('door_unlock')
         unlock_timer_state = "On"
         unlock_end_time = end_time
-        text = "I've unlocked your car, and it will stay unlocked for %s, until %s." % (SpeakDurationHM(unlock_duration.seconds/3600), SpeakTime(end_time))
+        text = "I've unlocked your car, and it will stay unlocked for %s, until %s." % (SpeakDurationHM(float(unlock_duration.seconds)/3600), SpeakTime(end_time))
         data = vehicle.data_request('vehicle_state')
         unlock_timer = Timer(unlock_duration.seconds, LockCarAction) # Lock the car back up after 'minutes'
         unlock_timer.start()


### PR DESCRIPTION
The variable unlock_duration.seconds is an integer so when you convert it to an hour by dividing by 3600 it returns an integer, which is often 0.  So I have converted it to a float before doing the division.  Hopefully this fixes this sort of issues, but there may be other when different duration timers are used.