### PR TITLE
Use state_long from geocoder, negating need for states dict.

### DIFF
--- a/application.py
+++ b/application.py
@@ -45,65 +45,6 @@ charge_start_time = datetime.now() # initialize charge_timer
 charge_timer = Timer(1,"")
 t = Timer(1, "")
 
-states = {
-        'AK': 'Alaska',
-        'AL': 'Alabama',
-        'AR': 'Arkansas',
-        'AS': 'American Samoa',
-        'AZ': 'Arizona',
-        'CA': 'California',
-        'CO': 'Colorado',
-        'CT': 'Connecticut',
-        'DC': 'District of Columbia',
-        'DE': 'Delaware',
-        'FL': 'Florida',
-        'GA': 'Georgia',
-        'GU': 'Guam',
-        'HI': 'Hawaii',
-        'IA': 'Iowa',
-        'ID': 'Idaho',
-        'IL': 'Illinois',
-        'IN': 'Indiana',
-        'KS': 'Kansas',
-        'KY': 'Kentucky',
-        'LA': 'Louisiana',
-        'MA': 'Massachusetts',
-        'MD': 'Maryland',
-        'ME': 'Maine',
-        'MI': 'Michigan',
-        'MN': 'Minnesota',
-        'MO': 'Missouri',
-        'MP': 'Northern Mariana Islands',
-        'MS': 'Mississippi',
-        'MT': 'Montana',
-        'NA': 'National',
-        'NC': 'North Carolina',
-        'ND': 'North Dakota',
-        'NE': 'Nebraska',
-        'NH': 'New Hampshire',
-        'NJ': 'New Jersey',
-        'NM': 'New Mexico',
-        'NV': 'Nevada',
-        'NY': 'New York',
-        'OH': 'Ohio',
-        'OK': 'Oklahoma',
-        'OR': 'Oregon',
-        'PA': 'Pennsylvania',
-        'PR': 'Puerto Rico',
-        'RI': 'Rhode Island',
-        'SC': 'South Carolina',
-        'SD': 'South Dakota',
-        'TN': 'Tennessee',
-        'TX': 'Texas',
-        'UT': 'Utah',
-        'VA': 'Virginia',
-        'VI': 'Virgin Islands',
-        'VT': 'Vermont',
-        'WA': 'Washington',
-        'WI': 'Wisconsin',
-        'WV': 'West Virginia',
-        'WY': 'Wyoming'
-}
 
 def IdentifyStateName(abbr):
     state_name = states[abbr]
@@ -241,8 +182,8 @@ def GetLocation():
     longitude = data['longitude']
     location = geocoder.google([latitude, longitude], method='reverse')
     text = "Right now, your car is in %s " % location.city
-    if location.country == "US":
-        text += "%s, at " % IdentifyStateName(location.state)
+    if location.country in ["US","CA,"AU"]:
+        text += "%s, at " % location.state_long
     else:
         text += "%s, at " % location.country
     text += "%s " % location.housenumber


### PR DESCRIPTION
Geocoder has a property called state_long.  This returns the full state or province name in long form, ie as New Hampshire rather than NH.  I have tried it for the US, Canada and Australia so far.  We can always expand the list from these countries if we find that it works for my countries.