### PR TITLE
OAUTH

### DIFF
--- a/application.py
+++ b/application.py
@@ -58,19 +58,15 @@ def assign_tesla_token():
 
 # Tesla API connection
 # Tesla Username and Password are stored separately as environment variables
-@ask.on_session_started  
-def create_tesla_connection():
-    global ASSIGNED_TOKEN, vehicle
-    TESLA_USER = os.environ['TESLA_USER']
-    TESLA_PASSWORD = os.environ['TESLA_PASSWORD']
-    ASSIGNED_TOKEN = assign_tesla_token()
+TESLA_USER = os.environ['TESLA_USER']
+TESLA_PASSWORD = os.environ['TESLA_PASSWORD']
+ASSIGNED_TOKEN = assign_tesla_token()
 
-    if use_token():
-        tesla_connection = teslajson.Connection(TESLA_USER, TESLA_PASSWORD, ASSIGNED_TOKEN)
-    else:
-        tesla_connection = teslajson.Connection(TESLA_USER, TESLA_PASSWORD)
-    vehicle = tesla_connection.vehicles[0]
-    return
+if use_token():
+    tesla_connection = teslajson.Connection(TESLA_USER, TESLA_PASSWORD, ASSIGNED_TOKEN)
+else:
+    tesla_connection = teslajson.Connection(TESLA_USER, TESLA_PASSWORD)
+vehicle = tesla_connection.vehicles[0]
 
 #Global State Variables
 unlock_timer_state = "Off" # Start with unlock_timer_state "Off"


### PR DESCRIPTION
The OAUTH token can be passed in (by Alexa or anyone else calling this) and that will prevent using TESLA_USERID and TESLA_PASSWORD. A locally stored environment variable called TESLA_TOKEN can also be used instead of passing in an OAUTH token.

A new environment variable called USE_TOKEN can be set to YES to switch over the instance to using OAUTH tokens (if available) versus USERID + PASSWORD. This is so those who are unfamiliar with OAUTH tokens and those who are to be able to use the same code base. Any value other than YES (even just Y) will use the USERID + PASSWORD process.